### PR TITLE
res.socket is not always defined

### DIFF
--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -38,7 +38,7 @@ Cookies.prototype = {
     var res = this.response
       , req = this.request
       , headers = res.getHeader( "Set-Cookie" ) || []
-      , secure = res.socket.encrypted || req.connection.proxySecure
+      , secure = res.socket ? res.socket.encrypted || req.connection.proxySecure : req.connection.proxySecure
       , cookie = new Cookie( name, value, opts )
       , header
       


### PR DESCRIPTION
Check if it is undefined first before trying to read res.socket.encrypted
