### PR TITLE
Fix #10 Default signedness based on presence of keys

### DIFF
--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -10,6 +10,7 @@ Cookies.prototype = {
   get: function( name, opts ) {
     var sigName = name + ".sig"
       , header, match, value, remote, data, index
+      , signed = opts && opts.signed !== undefined ? opts.signed : !!this.keys
       
     header = this.request.headers[ "cookie" ]
     if ( !header ) return    
@@ -18,7 +19,7 @@ Cookies.prototype = {
     if ( !match ) return
     
     value = match[ 1 ]
-    if ( !opts || !opts.signed ) return value
+    if ( !opts || !signed ) return value
 
     remote = this.get( sigName )
     if ( !remote ) return
@@ -41,6 +42,7 @@ Cookies.prototype = {
       , secure = res.socket ? res.socket.encrypted || req.connection.proxySecure : req.connection.proxySecure
       , cookie = new Cookie( name, value, opts )
       , header
+      , signed = opts && opts.signed !== undefined ? opts.signed : !!this.keys
       
     if ( typeof headers == "string" ) headers = [ headers ]
       
@@ -50,7 +52,7 @@ Cookies.prototype = {
     if (opts && "secure" in opts) cookie.secure = opts.secure
     headers.push( cookie.toHeader() )
     
-    if ( opts && opts.signed ) {
+    if ( opts && signed ) {
       cookie.value = this.keys.sign( cookie.toString() )
       cookie.name += ".sig"
       headers.push( cookie.toHeader() )


### PR DESCRIPTION
Explicitly setting `signed: <value>` will override the default, but otherwise, try to infer the desire for signedness from the fact that a signing agent is available (why go through the trouble to include Keygrip and pass an instance to Cookies, if you _don't_ want signed cookies?)
