### PR TITLE
tiny update to tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
+  - 0.8
   - 0.6

--- a/test/express.js
+++ b/test/express.js
@@ -46,7 +46,9 @@ app.get("/", function(req, res) {
   )
 })
 
-app.listen( 8000 )
+var server = require('http').createServer(app);
+
+server.listen( 8000 )
 
 http.get( options, function( res ) {
   var header = res.headers[ "set-cookie" ]
@@ -61,6 +63,6 @@ http.get( options, function( res ) {
   http.get( options, function( res ) {
     res.on( "data", function( chunk ){ body += chunk } )
     res.on( "end", function(){ console.log( body ) })
-    app.close()
+    server.close()
   })
 })


### PR DESCRIPTION
Howdy - I just updated the travis runner & test to be api compatible with newer versions of express.  I did this as a precursor to a larger change I'd like to discuss.

I'd like to add a `string value = Cookies.parse(string cookieData, [object KeyGrip])` static method which does not require an instantiated an Cookies object, a request, or a response.  

Primarily useful for parsing cookies from [handshake data in socket.io](https://github.com/LearnBoost/socket.io/wiki/Authorizing).  I also think the `cookie.get` method does maybe a bit too much (command/query separation, SRP, bla bla bla) so this would provide a "read only" way to access cookie data - if it's expired the method could just return null or something but not concern itself with modifying outgoing cookies on the response.

Thoughts on this before I bang it together?
