### PR TITLE
Revert case of set-cookie to Set-Cookie

### DIFF
--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -60,7 +60,7 @@ Cookies.prototype = {
     }
 
     var setHeader = res.set ? http.OutgoingMessage.prototype.setHeader : res.setHeader
-    setHeader.call(res, 'set-cookie', headers)
+    setHeader.call(res, 'Set-Cookie', headers)
     return this
   }
 }


### PR DESCRIPTION
I think this will be the easiest way to solve my problem.

Just want to be sure that using the lowercase wasn't part of the workaround to get it to not set the cookies multiple times. For what it's worth, I'm still noticing it duplicate cookies even after updating to the newest version...
