### PR TITLE
add throwing of an error when .keys are missing for signed option

### DIFF
--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -26,6 +26,7 @@ Cookies.prototype = {
     if (!remote) return
 
     data = name + "=" + value
+    if (!this.keys) throw new Error('.keys required for signed cookies');
     index = this.keys.index(data, remote)
 
     if (index < 0) {
@@ -54,6 +55,7 @@ Cookies.prototype = {
     headers = pushCookie(headers, cookie)
 
     if (opts && signed) {
+      if (!this.keys) throw new Error('.keys required for signed cookies');
       cookie.value = this.keys.sign(cookie.toString())
       cookie.name += ".sig"
       headers = pushCookie(headers, cookie)


### PR DESCRIPTION
otherwise all you get is TypeError: Cannot call method "sign" of undefined

usually im not a fan of defensive programming but in this case it's optional but if a user forgets to set `app.keys` or whatever their "global" key source might be then they'll get a potentially confusing error
