### PR TITLE
adding dynamic domain detection based on array based domains

### DIFF
--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -61,7 +61,7 @@ Cookies.prototype = {
       throw new Error('Cannot send secure cookie over unencrypted connection')
     }
 
-    if ( opts.domain && Array.isArray(opts.domain) && req.headers.host ) {
+    if ( opts && opts.domain && Array.isArray(opts.domain) && req.headers.host ) {
       // first add a dot infront to ensure they can match
       var host = "."+req.headers.host;
       var longestMatch = undefined;

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -61,6 +61,22 @@ Cookies.prototype = {
       throw new Error('Cannot send secure cookie over unencrypted connection')
     }
 
+    if ( opts.domain && Array.isArray(opts.domain) && req.headers.host ) {
+      // first add a dot infront to ensure they can match
+      var host = "."+req.headers.host;
+      var longestMatch = undefined;
+
+      for ( var i = 0; i < opts.domain.length; i++ ) {
+        if ( host.endsWith(opts.domain[i]) ) {
+          if ( !longestMatch || longestMatch.length < opts.domain[i].length) {
+            longestMatch = opts.domain[i];
+          }
+        }
+      }
+
+      cookie.domain = longestMatch || opts.domain[0];
+    }
+
     cookie.secure = secure
     if (opts && "secure" in opts) cookie.secure = opts.secure
     if (opts && "secureProxy" in opts) cookie.secure = opts.secureProxy


### PR DESCRIPTION
So basically for my company's use case, we kinda made use of different domains that shares a certain key, and then could read the session from the same session store. By adding this, now this cookie implementation can match longest matched domain based on an array, basically now allowing cookies to be "white-listed" instead of using something like wild-case. 

For example:

passport.fooa.com -> login with domain = .fooa.com -> redirect to passport.foob.com with a key -> checks the key, reads the session from backend, throws a cookie back with the same sessionid or whatsoever with domain = .foob.com

this allows a cluster of instances for this passport server to be used for different domains.
