### PR TITLE
autoSet option for cookie get.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ This adds cookie support as a Connect middleware layer for use in Express apps, 
 
 This extracts the cookie with the given name from the `Cookie` header in the request. If such a cookie exists, its value is returned. Otherwise, nothing is returned.
 
-`{ signed: true }` can optionally be passed as the second parameter _options_. In this case, a signature cookie (a cookie of same name ending with the `.sig` suffix appended) is fetched. If no such cookie exists, nothing is returned.
+If the _options_ object is provided, the following options can be passed:
+
+* `signed`: If true, a signature cookie (a cookie of same name ending with the `.sig` suffix appended) is fetched. If no such cookie exists, nothing is returned. false unless keys were passed to the constructor.
+* `autoSet`: If true, the act of getting a cookie from the request will ensure that the cookie is set on the outgoing response.  If false, the outgoing response will not have the cookie set unless it is actively set.  Defaults to true.
 
 If the signature cookie _does_ exist, the provided [Keygrip](https://www.npmjs.com/package/keygrip) object is used to check whether the hash of _cookie-name_=_cookie-value_ matches that of any registered key:
 

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -32,6 +32,7 @@ Cookies.prototype = {
     var sigName = name + ".sig"
       , header, match, value, remote, data, index
       , signed = opts && opts.signed !== undefined ? opts.signed : !!this.keys
+      , autoSet = opts && opts.autoSet === false ? false : true
 
     header = this.request.headers["cookie"]
     if (!header) return
@@ -50,9 +51,9 @@ Cookies.prototype = {
     index = this.keys.index(data, remote)
 
     if (index < 0) {
-      this.set(sigName, null, {path: "/", signed: false })
+      if (autoSet) this.set(sigName, null, {path: "/", signed: false })
     } else {
-      index && this.set(sigName, this.keys.sign(data), { signed: false })
+      if (autoSet) index && this.set(sigName, this.keys.sign(data), { signed: false })
       return value
     }
   },


### PR DESCRIPTION
This adds another option to the get function which can be used to control whether a get operation also performs a set on the outgoing response.  In some security profiles you do not want to send a cookie back on every response, but only when it changed.  This wasn't possible with the current implementation as it always would set the cookie on the response whenever one read the cookie.
