### PR TITLE
maxAge should not be translated to expires

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,6 +148,7 @@ function Cookie(name, value, attrs) {
 }
 
 Cookie.prototype.path = "/";
+Cookie.prototype.maxAgeRfc = undefined;
 Cookie.prototype.expires = undefined;
 Cookie.prototype.domain = undefined;
 Cookie.prototype.httpOnly = true;
@@ -162,10 +163,14 @@ Cookie.prototype.toString = function() {
 Cookie.prototype.toHeader = function() {
   var header = this.toString()
 
-  if (this.maxAge) this.expires = new Date(Date.now() + this.maxAge);
-
   if (this.path     ) header += "; path=" + this.path
-  if (this.expires  ) header += "; expires=" + this.expires.toUTCString()
+  if (this.maxAgeRfc) {
+    header += "; max-age=" + this.maxAgeRfc;
+  } else {
+    if (this.maxAge) this.expires = new Date(Date.now() + this.maxAge);
+    if (this.expires) header += "; expires=" + this.expires.toUTCString()
+  }
+
   if (this.domain   ) header += "; domain=" + this.domain
   if (this.sameSite ) header += "; samesite=" + (this.sameSite === true ? 'strict' : this.sameSite.toLowerCase())
   if (this.secure   ) header += "; secure"

--- a/test/cookie.js
+++ b/test/cookie.js
@@ -43,6 +43,16 @@ describe('new Cookie(name, value, [options])', function () {
         var cookie = new cookies.Cookie('foo', 'bar', { maxage: 86400 })
         assert.equal(cookie.maxage, 86400)
       })
+
+      it('should not set max-age attribute', function () {
+        var cookie = new cookies.Cookie('foo', 'bar', { maxage: 86400 })
+        assert.equal(/; max-age=/.test(cookie.toHeader()), false)
+      })
+
+      it('should set expires attribute', function () {
+        var cookie = new cookies.Cookie('foo', 'bar', { maxage: 86400 })
+        assert.equal(/; expires=/.test(cookie.toHeader()), true)
+      })
     })
 
     describe('maxAge', function () {
@@ -54,6 +64,17 @@ describe('new Cookie(name, value, [options])', function () {
       it('should set the .maxage property', function () {
         var cookie = new cookies.Cookie('foo', 'bar', { maxAge: 86400 })
         assert.equal(cookie.maxage, 86400)
+      })
+    })
+
+    describe('maxAgeRfc', function () {
+      it('should set the max-age attribute', function () {
+        var cookie = new cookies.Cookie('foo', 'bar', { maxAgeRfc: 86400 })
+        assert.equal(cookie.toHeader(), 'foo=bar; path=/; max-age=86400; httponly')
+      })
+      it('should take precedence over maxAge(expires)', function () {
+        var cookie = new cookies.Cookie('foo', 'bar', { maxAgeRfc: 86400, maxAge: 3600 })
+        assert.equal(cookie.toHeader(), 'foo=bar; path=/; max-age=86400; httponly')
       })
     })
 


### PR DESCRIPTION
The expires argument includes the timezone, but the UA clock might
be offset by a couple of hours (incorrect timezone), which would
end-up in the following situation:

 - UTC is 2018-01-15 10:00 + 00:00
   Client has localtime: 2018-01-15 10:00 - 08:00 (8h in the future)
 - Server set cookie with maxAge = 30min
 - Server send:
     Set-Cookie: foo=bar; expires=2018-01-15T10:30:00+00:00
 - UA immediately expires the cookie
 - UA send a new request without cookie.

Sadly incorrect UA clock is a common problem (at least for us),
maxAge is a correct option (as the time is calculated relative
to UA clock), but this is not an available option in this library.

Fix #58 