### PR TITLE
Fix an edge case in koa

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ Cookies.prototype.set = function(name, value, opts) {
 
   headers = pushCookie(headers, cookie)
 
-  if (opts && signed) {
+  if (signed) {
     if (!this.keys) throw new Error('.keys required for signed cookies');
     cookie.value = this.keys.sign(cookie.toString())
     cookie.name += ".sig"


### PR DESCRIPTION
In koa, we set app keys:

```js
const app = new Koa()
app.keys = ['sk1', 'sk2']
```

And we expect that all cookies will be signed by default when no opts supplied 

```js
ctx.cookies.set(name, value)
```

Or else, we need to do some unfancy jobs

```js
ctx.cookies.set(name, value, {})
```