### PR TITLE
Fix cookie removal

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,7 +162,7 @@ Cookie.prototype.toString = function() {
 Cookie.prototype.toHeader = function() {
   var header = this.toString()
 
-  if (this.maxAge) this.expires = new Date(Date.now() + this.maxAge);
+  if (this.value && this.maxAge) this.expires = new Date(Date.now() + this.maxAge);
 
   if (this.path     ) header += "; path=" + this.path
   if (this.expires  ) header += "; expires=" + this.expires.toUTCString()


### PR DESCRIPTION
A cookie set with an empty value means removal.

So even if `maxAge` exists in settings, it should not affect expiration, the is in the past.
Otherwise, cookie removal creates an live empty cookie instead.