### PR TITLE
Send `max-age` header as well as `expires` if it is set

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,6 +164,7 @@ Cookie.prototype.toHeader = function() {
 
   if (this.maxAge) this.expires = new Date(Date.now() + this.maxAge);
 
+  if (this.maxAge   ) header += "; max-age=" + this.maxAge
   if (this.path     ) header += "; path=" + this.path
   if (this.expires  ) header += "; expires=" + this.expires.toUTCString()
   if (this.domain   ) header += "; domain=" + this.domain

--- a/test/test.js
+++ b/test/test.js
@@ -297,7 +297,7 @@ describe('new Cookies(req, res, [options])', function () {
         .end(done)
       })
 
-      it('should not set the "maxAge" attribute', function (done) {
+      it('should set the "maxAge" attribute', function (done) {
         request(createServer(function (req, res, cookies) {
           cookies.set('foo', 'bar', { maxAge: 86400000 })
           res.end()
@@ -305,7 +305,7 @@ describe('new Cookies(req, res, [options])', function () {
         .get('/')
         .expect(200)
         .expect(shouldSetCookieWithAttribute('foo', 'expires'))
-        .expect(shouldSetCookieWithoutAttribute('foo', 'maxAge'))
+        .expect(shouldSetCookieWithAttribute('foo', 'max-age'))
         .end(done)
       })
     })


### PR DESCRIPTION
It can be necessary to use `max-age` rather than rely on `expires`, when the client and server clocks are not in sync.

Older versions of IE will ignore the `max-age` and use the `expires` value. Any browser which supports `max-age` will use it in preference of `expires` if both are present.