### PR TITLE
fix: ignore secure option when undefined

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 unreleased
 ==========
 
+  * Fix check for default `secure` option behavior
   * deps: depd@~2.0.0
     - Replace internal `eval` usage with `Function` constructor
     - Use instance methods on `process` to check for listeners

--- a/index.js
+++ b/index.js
@@ -94,8 +94,9 @@ Cookies.prototype.set = function(name, value, opts) {
     throw new Error('Cannot send secure cookie over unencrypted connection')
   }
 
-  cookie.secure = secure
-  if (opts && "secure" in opts) cookie.secure = opts.secure
+  cookie.secure = opts && opts.secure !== undefined
+    ? opts.secure
+    : secure
 
   if (opts && "secureProxy" in opts) {
     deprecate('"secureProxy" option; use "secure" option, provide "secure" to constructor if needed')

--- a/test/test.js
+++ b/test/test.js
@@ -401,6 +401,45 @@ describe('new Cookies(req, res, [options])', function () {
           })
         })
       })
+
+      describe('when undefined', function () {
+        it('should set secure attribute on encrypted connection', function (done) {
+          var server = createSecureServer(setCookieHandler('foo', 'bar', { secure: undefined }))
+
+          request(server)
+            .get('/')
+            .ca(server.cert)
+            .expect(200)
+            .expect(shouldSetCookieWithAttribute('foo', 'Secure'))
+            .end(done)
+        })
+
+        describe('with "secure: undefined" constructor option', function () {
+          it('should not set secure attribute on unencrypted connection', function (done) {
+            var opts = { secure: undefined }
+
+            request(createServer(opts, setCookieHandler('foo', 'bar', { secure: undefined })))
+              .get('/')
+              .expect(200)
+              .expect(shouldSetCookieWithoutAttribute('foo', 'Secure'))
+              .end(done)
+          })
+        })
+
+        describe('with req.protocol === "https"', function () {
+          it('should set secure attribute on unencrypted connection', function (done) {
+            request(createServer(function (req, res, cookies) {
+              req.protocol = 'https'
+              cookies.set('foo', 'bar', { secure: undefined })
+              res.end()
+            }))
+              .get('/')
+              .expect(200)
+              .expect(shouldSetCookieWithAttribute('foo', 'Secure'))
+              .end(done)
+          })
+        })
+      })
     })
 
     describe('"secureProxy" option', function () {


### PR DESCRIPTION
I assumed passing an option as `undefined` would have the default behaviour kick.

This is the case for the `signed` option. In case of the `secure` option tho, it means cookies are never sent as Secure even on encrypted or `req.protocol === "https"` requests so as if `false` was passed in.

This PR fixes that and adds tests.