### PR TITLE
URL Decoding of Raw Cookie Values

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,14 @@ Cookies.prototype.get = function(name, opts) {
   match = header.match(getPattern(name))
   if (!match) return
 
-  value = match[1]
+  /*
+   * https://tools.ietf.org/html/rfc6265#section-4.1.1
+   *
+   * To maximize compatibility with user agents, servers that wish to
+   * store arbitrary data in a cookie-value SHOULD encode that data, for
+   * example, using Base64 [RFC4648].
+   */
+  value = decodeURIComponent(match[1])
   if (!opts || !signed) return value
 
   remote = this.get(sigName)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cookies",
   "description": "Cookies, optionally signed using Keygrip.",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "author": "Jed Schmidt <tr@nslator.jp> (http://jed.is)",
   "contributors": [
     "Douglas Christopher Wilson <doug@somethingdoug.com>"

--- a/test/test.js
+++ b/test/test.js
@@ -80,8 +80,8 @@ describe('new Cookies(req, res, [options])', function () {
         res.end(String(cookies.get('foo')))
       }))
       .get('/')
-      .set('Cookie', 'foo=bar')
-      .expect(200, 'bar', done)
+      .set('Cookie', 'foo=bar%3D')
+      .expect(200, 'bar=', done)
     })
 
     it('should work for cookie name with special characters', function (done) {


### PR DESCRIPTION
URL decoding of raw cookie header key-value pairs as recommended by h…ttps://tools.ietf.org/html/rfc6265#section-4.1.1

Using cookie-session, signed cookies are not recognized when the serialized session cookie contains special characters such as `=`, since they end up being url encoded. This PR will URL Decode the raw values parsed from the cookie header.