### PR TITLE
Require cookie value to be string (unset omitted or null)

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,6 +121,10 @@ function Cookie(name, value, attrs) {
     throw new TypeError('argument name is invalid');
   }
 
+  if (value !== undefined && value !== null && typeof value !== 'string') {
+    throw new Error('argument value is not a string');
+  }
+
   if (value && !fieldContentRegExp.test(value)) {
     throw new TypeError('argument value is invalid');
   }

--- a/test/cookie.js
+++ b/test/cookie.js
@@ -32,6 +32,18 @@ describe('new Cookie(name, value, [options])', function () {
     }, /option domain is invalid/)
   })
 
+  it('should throw on number value', function () {
+    assert.throws(function () {
+      new cookies.Cookie('foo', 0)
+    }, /argument value is not a string/)
+  })
+
+  it('should throw on boolean value', function () {
+    assert.throws(function () {
+      new cookies.Cookie('foo', false)
+    }, /argument value is not a string/)
+  })
+
   describe('options', function () {
     describe('maxage', function () {
       it('should set the .maxAge property', function () {


### PR DESCRIPTION
Resolves #101.

This enforces string input as suggested by @dougwilson. 

Two considerations:
 * Is input a string if wrapped in `String` constructor? I suggest *no*, as do [Node](https://github.com/nodejs/node/blob/a0e2c6d2843ea6e37035a949827cdcc7949026d6/lib/internal/validators.js#L112). That is also what I went with in the PR.
 * When is input *omitted*? Logically `undefined`. But there are tests for expiring cookies using `null`. What about `false`? I feel `undefined` and `null` should cover it (although an explicit `Cookies.unset` would avoid ambiguity).