### PR TITLE
Add return keyword if sigName is invalid when calling cookies.get

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,6 +74,7 @@ Cookies.prototype.get = function(name, opts) {
 
   if (index < 0) {
     this.set(sigName, null, {path: "/", signed: false })
+    return
   } else {
     index && this.set(sigName, this.keys.sign(data), { signed: false })
     return value


### PR DESCRIPTION
This `PR` is just to make the code and logic more rigorous.