### PR TITLE
Send Max-Age header if maxAge is given

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,6 +170,7 @@ Cookie.prototype.toHeader = function() {
 
   if (this.path     ) header += "; path=" + this.path
   if (this.expires  ) header += "; expires=" + this.expires.toUTCString()
+  if (this.maxAge   ) header += "; max-age=" + this.maxAge / 1000
   if (this.domain   ) header += "; domain=" + this.domain
   if (this.sameSite ) header += "; samesite=" + (this.sameSite === true ? 'strict' : this.sameSite.toLowerCase())
   if (this.secure   ) header += "; secure"


### PR DESCRIPTION
Max-age is less error prone because it doesn't rely on date and time synchronization between server and client.