### PR TITLE
don't check when setting cookie.secure to true

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,10 +90,6 @@ Cookies.prototype.set = function(name, value, opts) {
 
   if (typeof headers == "string") headers = [headers]
 
-  if (!secure && opts && opts.secure) {
-    throw new Error('Cannot send secure cookie over unencrypted connection')
-  }
-
   cookie.secure = opts && opts.secure !== undefined
     ? opts.secure
     : secure


### PR DESCRIPTION
When the web server is behind a `nginx`, the value of `this.secure` is always `false` thought we use `https` protocol to connect the nginx. So we will get the error like this:
```
koa-generic-session set error: Cannot send secure cookie over unencrypted connection
  at Cookies.set (/node_modules/cookies/index.js:94:11)
  at Object.set (/node_modules/koa-generic-session/lib/session.js:93:20)
  at Object.saveNow (/node_modules/koa-generic-session/lib/session.js:280:26)
  at saveNow.next (<anonymous>)
  at onFulfilled (/node_modules/co/index.js:65:19)
  at <anonymous>
  at process._tickCallback (internal/process/next_tick.js:182:7)
```

Because of this check, we can't use `cookie.secure` anymore if the web servers are behind the nginx.
So I suggest to remove the secure connection check when we set `cookie.secure=true`. 

Signed-off-by: lfbzhm <lifubang@acmcoder.com>