### PR TITLE
Strip quotes for cookie values for .get()

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@ unreleased
 ==========
 
   * Fix accidental cookie name/value truncation when given invalid chars
+  * Remove quotes from returned quoted cookie value
   * Use `req.socket` over deprecated `req.connection`
   * pref: small lookup regexp optimization
 

--- a/index.js
+++ b/index.js
@@ -80,6 +80,7 @@ Cookies.prototype.get = function(name, opts) {
   if (!match) return
 
   value = match[1]
+  if (value[0] === '"') value = value.slice(1, -1)
   if (!opts || !signed) return value
 
   remote = this.get(sigName)

--- a/test/test.js
+++ b/test/test.js
@@ -82,6 +82,13 @@ describe('new Cookies(req, res, [options])', function () {
         .expect(200, 'bar', done)
     })
 
+    it('should return unquoted value', function (done) {
+      request(createServer(getCookieHandler('foo')))
+        .get('/')
+        .set('Cookie', 'foo="bar"')
+        .expect(200, 'bar', done)
+    })
+
     it('should work for cookie name with special characters', function (done) {
       request(createServer(getCookieHandler('foo*(#bar)?.|$')))
         .get('/')


### PR DESCRIPTION
According to [RFC 2965](https://www.ietf.org/rfc/rfc2965.txt), cookie value can be "quoted-string" and in practice, some web framework (e.g. Java Spring) sometimes uses quoted value.
In such cases, web browser will send HTTP headers like `Cookie: my_value_a=x; my_value_b="abc:def:xyz";` to the server and it will be more developer friendly to automatically strip quotes so that `cookie.get('my_value_b')` returns `abc:def:xyz` rather than `"abc:def:xyz"`.

### Is this this library's responsibility?
I guess so. I checked the behavior of Django and Express and both of them strip quotes under the hood.

- [Django](https://github.com/django/django)
  - [Django is explicitly stripping quotes when creating COOKIES dict](https://github.com/django/django/blob/f5669fd7b568cf8a3eda1e65c1c6fb583c7b177d/django/http/cookie.py#L20-L22) using [Python's undocumented `_unquote` function](https://github.com/python/cpython/blob/3.9/Lib/http/cookies.py#L190)

- [Express](https://github.com/expressjs/express)
  - [Official doc for req.cookies](http://expressjs.com/en/5x/api.html#req.cookies)
  - [In the official cookie middieware, it's using cookie.parse](https://github.com/expressjs/cookie-parser/blob/6918b5081aec7d76072a17359106ff9b5d39a487/index.js#L60)
  - [And cookie.parse is explicitly unquoting it](https://github.com/jshttp/cookie/blob/0b519534a5d0bea176f8422aeb93f7d9fce8d683/index.js#L72)

### What's the impact of this change?
[koa is relying on this library](https://github.com/koajs/koa/blob/698ce0afbfac6480400625729a4b8fc4b4203fdc/lib/context.js#L13). After this fix, koa can get the same behavior as Django and Express, which seems to be more reasonable and common behavior. I created [an issue for koa](https://github.com/koajs/koa/issues/1561) for the discussion in koa side.

Note that this change will be breaking change so we need to bump up the major version of the library.
